### PR TITLE
Fix build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+buildscript {
+  repositories {
+    mavenCentral()
+    maven { url 'https://nexus.web.cern.ch/nexus/content/repositories/public/' }
+  }
+}
+
 plugins {
   id "com.jfrog.bintray" version "1.8.5"
   id "java"
@@ -11,10 +18,11 @@ plugins {
 
 repositories {
   mavenCentral()
+  maven { url 'https://nexus.web.cern.ch/nexus/content/repositories/public/' }
 }
 
 group = "io.github.yuokada"
-version = "0.6.0"
+version = "0.7.0"
 description = "Embulk plugin for generate dummy records by Java."
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
Fix `build.gradle` based on the following answer.

see: [android \- Could not find http\-builder\-0\.7\.2\.jar \(org\.codehaus\.groovy\.modules\.http\-builder:http\-builder:0\.7\.2\) \- Stack Overflow](https://stackoverflow.com/questions/79073916/could-not-find-http-builder-0-7-2-jar-org-codehaus-groovy-modules-http-builder)