### PR TITLE
chore: upgrade checkstyle to v9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ embulkPlugin {
 
 checkstyle {
   configFile = file("${project.rootDir}/config/checkstyle/checkstyle.xml")
-  toolVersion = '6.19'
+  toolVersion = '9.3'
 }
 checkstyleMain {
   configFile = file("${project.rootDir}/config/checkstyle/default.xml")


### PR DESCRIPTION
## Summary
- bump Checkstyle toolVersion to 9.3

## Testing
- `./gradlew check` *(fails: JAVA_HOME is not set and no `java` command could be found in your PATH)*

------
https://chatgpt.com/codex/tasks/task_e_6899b4a2364c8329b33daca993f2e578